### PR TITLE
Bug: Shortened URLs fail with trailing slash (#3)

### DIFF
--- a/src/main/java/io/github/kientux/OpenGrape.java
+++ b/src/main/java/io/github/kientux/OpenGrape.java
@@ -1,7 +1,7 @@
 package io.github.kientux;
 
-import io.github.kientux.parser.OpenGrapeParser;
 import io.github.kientux.parser.DefaultOpenGrapeParser;
+import io.github.kientux.parser.OpenGrapeParser;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -21,6 +21,9 @@ public class OpenGrape {
     }
 
     public static OpenGrape fetch(String url) throws IOException, OpenGrapeResponseException {
+        if (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         int statusCode = connection.getResponseCode();
         if (statusCode < 200 || statusCode > 300) {

--- a/src/test/java/io/github/kientux/OpenGrapeTest.java
+++ b/src/test/java/io/github/kientux/OpenGrapeTest.java
@@ -24,4 +24,38 @@ public class OpenGrapeTest {
             fail();
         }
     }
+
+    @Test
+    public void givenShortenedUrl_whenParseOGTag_thenCorrect() {
+        String url = "https://bit.ly/3SGKNmU";
+        try {
+            OpenGrape og = OpenGrape.fetch(url);
+            String title = og.getValue(OpenGrapeMetadata.TITLE);
+            String description = og.getValue(OpenGrapeMetadata.DESCRIPTION);
+            String image = og.getValue(OpenGrapeMetadata.IMAGE);
+            assertEquals("Open Graph protocol", title);
+            assertEquals("https://ogp.me/logo.png", image);
+            assertEquals("The Open Graph protocol enables any web page to become a rich object in a social graph.", description);
+        } catch (IOException | OpenGrapeResponseException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void givenShortenedUrlWithTrailingSlash_whenParseOGTag_thenCorrect() {
+        String url = "https://bit.ly/3SGKNmU/";
+        try {
+            OpenGrape og = OpenGrape.fetch(url);
+            String title = og.getValue(OpenGrapeMetadata.TITLE);
+            String description = og.getValue(OpenGrapeMetadata.DESCRIPTION);
+            String image = og.getValue(OpenGrapeMetadata.IMAGE);
+            assertEquals("Open Graph protocol", title);
+            assertEquals("https://ogp.me/logo.png", image);
+            assertEquals("The Open Graph protocol enables any web page to become a rich object in a social graph.", description);
+        } catch (IOException | OpenGrapeResponseException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
 }


### PR DESCRIPTION
This commit strips off any trailing slashes from the URL being parsed.